### PR TITLE
Works on 3.4.3

### DIFF
--- a/reindent.py
+++ b/reindent.py
@@ -102,7 +102,7 @@ def check(file, options=parser.parse_args([])):
 				bak = file + '.bak'
 				copyfile(file, bak)
 				logging.info('backed up %s to %s.', file, bak)
-			with open(file, encoding=encoding) as f:
+			with open(file, 'w', encoding=encoding) as f:
 				indenter.write(f)
 			logging.info('wrote new %s.', file)
 		return True

--- a/reindent.py
+++ b/reindent.py
@@ -151,7 +151,7 @@ class Reindenter:
 				self.after.append(line)
 				
 				sym = '×' if l == lineno - 1 else ' '
-				logging.debug("{}{:3} {:31} |{!r}".format(sym, l, stat, line))
+				logging.debug("{}{:3} {!r:31} |{}".format(sym, l, stat, line))
 			
 			last_stat_on = l+1
 		

--- a/reindent.py
+++ b/reindent.py
@@ -100,6 +100,14 @@ def check(file, options=parser.parse_args([])):
 		else:
 			if options.backup:
 				bak = file + '.bak'
+				# do not overwrite another backup file
+				if os.path.exists(bak):
+					n = 1
+					bak += str(n)
+					while os.path.exists(bak):
+						bak = '{}{}'.format(bak[:-1], n)
+						n += 1
+					
 				copyfile(file, bak)
 				logging.info('backed up %s to %s.', file, bak)
 			with open(file, 'w', encoding=encoding) as f:


### PR DESCRIPTION
I was glad to see your version of the reindent and I am so grateful for it. I think tabs are the sane way of indenting and this script saves much time. I was unable to use it without modifications, however. So I fixed it to work on Python 3.4.3. I am not sure what you intend to log on line 154.